### PR TITLE
Feature/textsave

### DIFF
--- a/backend/moonsunpowerback/moonsunpowerai/serializers.py
+++ b/backend/moonsunpowerback/moonsunpowerai/serializers.py
@@ -1,23 +1,41 @@
-# serializers.py
 from rest_framework import serializers
-from .models import Text, GeneratedText, QuestionItem
+from .models import CustomText, GeneratedText, QuestionItem, SolvedText
 
-# QuestionItem Serializer
+# 개별 질문 항목 Serializer
 class QuestionItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = QuestionItem
-        fields = ['question_text', 'choice1', 'choice2', 'choice3', 'choice4', 'choice5', 'answer', 'explanation']
+        fields = [
+            'question_text',
+            'choice1', 'choice2', 'choice3', 'choice4', 'choice5',
+            'answer', 'explanation'
+        ]
 
-# GeneratedText Serializer
+
+# GeneratedText용 Serializer (자동 생성 지문)
 class GeneratedTextSerializer(serializers.ModelSerializer):
-    questions = QuestionItemSerializer(many=True, source='question_items')  # `related_name` 사용
+    questions = QuestionItemSerializer(many=True, source='question_items')  # related_name 사용
 
     class Meta:
         model = GeneratedText
-        fields = ['content', 'date', 'questions']
+        fields = ['id', 'subject', 'content', 'date', 'created_at', 'questions']
 
-# Text Serializer 
-class TextSerializer(serializers.ModelSerializer):
+
+# CustomText용 Serializer (사용자 생성 지문)
+class CustomTextSerializer(serializers.ModelSerializer):
+    questions = QuestionItemSerializer(many=True, source='question_items')  # related_name 사용
+
     class Meta:
-        model = Text
-        fields = ['subject', 'difficulty', 'content', 'date']
+        model = CustomText
+        fields = [
+            'id', 'subject', 'difficulty', 'content',
+            'date', 'created_at', 'is_tag_text', 'questions'
+        ]
+
+# SolvedText용 Serializer (제출 이력)
+class SolvedTextSerializer(serializers.ModelSerializer):
+    custom_text = CustomTextSerializer()  # 전체 지문 정보 포함
+
+    class Meta:
+        model = SolvedText
+        fields = ['id', 'custom_text', 'solved_at']

--- a/backend/moonsunpowerback/moonsunpowerai/tasks.py
+++ b/backend/moonsunpowerback/moonsunpowerai/tasks.py
@@ -45,10 +45,10 @@ def generate_and_save_text():
     )
     
     content = response.choices[0].message.content  # response에서 content 가져오기
-
+    subject = response_data.get("subject", "").strip()
         # Text 객체 생성
     generated_text = GeneratedText.objects.create(
-        subject="do not know",
+        subject=subject if subject else "unknown",
         content=content
     )
     # Assuming `content` is in JSON format and contains questions

--- a/backend/moonsunpowerback/moonsunpowerai/urls.py
+++ b/backend/moonsunpowerback/moonsunpowerai/urls.py
@@ -6,5 +6,8 @@ urlpatterns = [
     path('text/<str:subject>/<int:difficulty>/<str:language>/', GenerateTextAPIView.as_view(), name='text-by-subject'),
     path('words/',UnknownWordsAPIView.as_view(),name='unknown-word'),
     path('tagtext/<int:subject>/<int:difficulty>',GenerateTagTextAPIView.as_view(),name='tag-text'),
+    path('submit/custom/<int:pk>/', SubmitCustomTextAPIView.as_view(), name='submit-custom'),
+    path('my-solved/', MySolvedTextsAPIView.as_view(), name='my-solved'),
+
 ]
 

--- a/backend/moonsunpowerback/moonsunpowerai/views.py
+++ b/backend/moonsunpowerback/moonsunpowerai/views.py
@@ -329,7 +329,7 @@ class GenerateTagTextAPIView(APIView):
             )
             
         response = client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=str(MODEL_SELECTOR.get(f"model_type_{difficulty}")).strip(),
             messages=[
                 {
                     "role": "system",
@@ -447,7 +447,7 @@ class UnknownWordsAPIView(APIView):
         
         client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
         response = client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=str(MODEL_SELECTOR.get(f"model_type_{difficulty}")).strip(),
             messages=[
                 {
                     "role": "system",

--- a/backend/moonsunpowerback/moonsunpowerai/views.py
+++ b/backend/moonsunpowerback/moonsunpowerai/views.py
@@ -7,10 +7,16 @@ from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 from rest_framework.permissions import AllowAny
 from openai import OpenAI
-from .models import CustomText, GeneratedText, QuestionItem
+from .models import CustomText, GeneratedText, QuestionItem, SolvedText
 from .prompts import *
 from dotenv import load_dotenv
-import re
+from rest_framework.permissions import IsAuthenticated
+from rest_framework import status
+from .serializers import SolvedTextSerializer
+from rest_framework.generics import ListAPIView
+from rest_framework.permissions import IsAuthenticated
+from .models import SolvedText
+
 
 load_dotenv()
 
@@ -248,6 +254,15 @@ class GenerateTextAPIView(APIView):
 
         return Response(response_data, status=status.HTTP_200_OK)
 
+TAG_SUBJECT_LABELS = {
+    1: "스포츠/예술",
+    2: "철학",
+    3: "사회/경제",
+    4: "과학/기술",
+    5: "문학",
+    6: "역사"
+}
+
 class GenerateTagTextAPIView(APIView):
     permission_classes = [AllowAny]
     @swagger_auto_schema(
@@ -365,11 +380,16 @@ class GenerateTagTextAPIView(APIView):
         main_content = content_data.get("content", "")
         questions = content_data.get("questions", [])
 
+        subject_name = TAG_SUBJECT_LABELS.get(subject, f"Unknown({subject})")
+
         generated_text = CustomText.objects.create(
-            subject=subject,
+            subject=subject_name,
             difficulty=difficulty,
-            content=main_content
+            content=main_content,
+            is_tag_text=True,
+            created_by=request.user if request.user.is_authenticated else None
         )
+
 
         questions_data = []
         for question in questions:
@@ -396,11 +416,12 @@ class GenerateTagTextAPIView(APIView):
             })
 
         response_data = {
-            "subject": generated_text.subject,
+            "subject": subject_name,
             "content": generated_text.content,
             "date": generated_text.date,
             "questions": questions_data
         }
+
 
         return Response(response_data, status=status.HTTP_200_OK)
 class UnknownWordsAPIView(APIView):
@@ -476,3 +497,33 @@ class UnknownWordsAPIView(APIView):
             )
         
         return Response(response_data, status=status.HTTP_200_OK)
+
+
+class SubmitCustomTextAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, pk):
+        try:
+            text = CustomText.objects.get(pk=pk)
+        except CustomText.DoesNotExist:
+            return Response({"error": "지문이 존재하지 않습니다."}, status=404)
+
+        # 중복 제출 방지
+        solved, created = SolvedText.objects.get_or_create(
+            user=request.user,
+            custom_text=text
+        )
+
+        if not created:
+            return Response({"message": "이미 제출한 지문입니다."}, status=200)
+
+        return Response({"message": "제출이 완료되었습니다."}, status=201)
+    
+
+
+class MySolvedTextsAPIView(ListAPIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = SolvedTextSerializer
+
+    def get_queryset(self):
+        return SolvedText.objects.filter(user=self.request.user).order_by('-solved_at')


### PR DESCRIPTION
SolvedText 모델 추가: 사용자의 지문 풀이 기록 저장
/submit/<int:pk>/ API 구현:
사용자가 특정 CustomText에 대해 풀이 완료 상태로 제출
중복 제출 방지 
#------
/mysolved/ API 구현:
사용자가 푼 지문 목록(SolvedText)을 조회
로그인 사용자 기준, 최신순 정렬

SolvedTextSerializer 구현: CustomText 내용을 포함한 풀이 이력 직렬화
생성 API(GenerateTextAPIView, GenerateTagTextAPIView)에서 지문 생성 시 사용자 연동 (created_by 저장)